### PR TITLE
Reworked TCs to avoid get_vid() usage

### DIFF
--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -7,23 +7,22 @@ from ptf.testutils import simple_tcp_packet, send_packet, verify_packets, verify
 
 def test_default_vrf(sai, dataplane):
     # Get default VRF
-    data = sai.get("SAI_OBJECT_TYPE_SWITCH:" + sai.sw_oid,
+    data = sai.get(sai.sw_oid,
                    ["SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID", "oid:0x0"]).to_json()
     assert data[0] == 'SAI_SWITCH_ATTR_DEFAULT_VIRTUAL_ROUTER_ID'
-    assert data[1] != 'oid:0x0'
+    vrf_oid = data[1]
+    assert vrf_oid != 'oid:0x0'
 
     # Set/Get one VRF attribute
-    sai.set("SAI_OBJECT_TYPE_VIRTUAL_ROUTER:" + data[1],
-            ["SAI_VIRTUAL_ROUTER_ATTR_ADMIN_V4_STATE", "true"])
+    sai.set(vrf_oid, ["SAI_VIRTUAL_ROUTER_ATTR_ADMIN_V4_STATE", "true"])
 
-    admin_v4_state = sai.get("SAI_OBJECT_TYPE_VIRTUAL_ROUTER:" + data[1],
-                             ["SAI_VIRTUAL_ROUTER_ATTR_ADMIN_V4_STATE", "true"]).to_json()
+    admin_v4_state = sai.get(vrf_oid, ["SAI_VIRTUAL_ROUTER_ATTR_ADMIN_V4_STATE", "true"]).to_json()
     assert admin_v4_state[1] == 'true'
 
     # Get multiple VRF attributes
     if not sai.libsaivs:
         # TODO: Not implemented for SONiC VS for the attributes that were not set before
-        attrs = sai.get("SAI_OBJECT_TYPE_VIRTUAL_ROUTER:" + data[1],
+        attrs = sai.get(vrf_oid,
                         [
                             "SAI_VIRTUAL_ROUTER_ATTR_ADMIN_V4_STATE", "true",
                             "SAI_VIRTUAL_ROUTER_ATTR_ADMIN_V6_STATE", "true",
@@ -36,125 +35,76 @@ def test_default_vrf(sai, dataplane):
     # Remove default VRF should cause SAI_STATUS_OBJECT_IN_USE
     if not sai.libsaivs:
         # TODO: Not implemented for SONiC VS
-        status = sai.remove("SAI_OBJECT_TYPE_VIRTUAL_ROUTER:" + data[1], False)
+        status = sai.remove(vrf_oid, False)
         assert (status == 'SAI_STATUS_OBJECT_IN_USE')
 
 
-def test_rif_create(sai, dataplane):
-    # Create VRF1
-    vrf_oid1 = sai.get_vid(SaiObjType.VIRTUAL_ROUTER, "vrf1")
-    sai.create("SAI_OBJECT_TYPE_VIRTUAL_ROUTER:" + vrf_oid1, [])
-
-    # Create VRF2
-    vrf_oid2 = sai.get_vid(SaiObjType.VIRTUAL_ROUTER, "vrf2")
-    sai.create("SAI_OBJECT_TYPE_VIRTUAL_ROUTER:" + vrf_oid2, [])
-
-    # Get .1Q bridge OID
-    dot1q_br = sai.get("SAI_OBJECT_TYPE_SWITCH:" + sai.sw_oid,
-                       ["SAI_SWITCH_ATTR_DEFAULT_1Q_BRIDGE_ID", "oid:0x0"])
-
-    # Retrieve the list of .1Q  ports
-    bport = sai.get("SAI_OBJECT_TYPE_BRIDGE:" + dot1q_br.oid(),
-                    ["SAI_BRIDGE_ATTR_PORT_LIST", sai.make_list(33, "oid:0x0")])
-    bport_oid = bport.oids()
+def test_rif_create_remove(sai, dataplane):
+    # Create VRFs
+    vrf_oid1 = sai.create(SaiObjType.VIRTUAL_ROUTER, [])
+    vrf_oid2 = sai.create(SaiObjType.VIRTUAL_ROUTER, [])
 
     # Remove ports
-    port_oid = []
-
-    for oid in bport_oid[0:3]:
-        sai.remove_vlan_member(sai.sw.default_vlan_id, oid)
-        port = sai.get("SAI_OBJECT_TYPE_BRIDGE_PORT:" + oid,
-                       ["SAI_BRIDGE_PORT_ATTR_PORT_ID", "oid:0x0"])
-        port_oid.append(port.oid())
-        sai.remove("SAI_OBJECT_TYPE_BRIDGE_PORT:" + oid)
+    for oid in sai.sw.dot1q_bp_oids[0:3]:
+        sai.remove_vlan_member(sai.sw.default_vlan_oid, oid)
+        sai.remove(oid)
 
     # Create RIF1
-    rif_oid1 = sai.get_vid(SaiObjType.ROUTER_INTERFACE, "rif1")
-    sai.create("SAI_OBJECT_TYPE_ROUTER_INTERFACE:" + rif_oid1,
-               [
-                   'SAI_ROUTER_INTERFACE_ATTR_TYPE', 'SAI_ROUTER_INTERFACE_TYPE_PORT',
-                   'SAI_ROUTER_INTERFACE_ATTR_PORT_ID', port_oid[0],
-                   'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID', vrf_oid1,
-               ])
+    rif_oid1 = sai.create(SaiObjType.ROUTER_INTERFACE,
+                          [
+                              'SAI_ROUTER_INTERFACE_ATTR_TYPE', 'SAI_ROUTER_INTERFACE_TYPE_PORT',
+                              'SAI_ROUTER_INTERFACE_ATTR_PORT_ID', sai.sw.port_oids[0],
+                              'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID', vrf_oid1,
+                          ])
 
     # Create LAG1
-    lag_oid = sai.get_vid(SaiObjType.LAG, "lag1")
-    sai.create("SAI_OBJECT_TYPE_LAG:" + lag_oid, [])
+    lag_oid = sai.create(SaiObjType.LAG, [])
 
     # Create LAG1 members
-    lag_members_id = []
-    for oid in port_oid[1:]:
-        sai.create("SAI_OBJECT_TYPE_LAG_MEMBER:" + sai.get_vid(SaiObjType.LAG_MEMBER, lag_oid + ',' + oid),
-                   [
-                       "SAI_LAG_MEMBER_ATTR_LAG_ID", lag_oid,
-                       "SAI_LAG_MEMBER_ATTR_PORT_ID", oid
-                   ])
-        lag_members_id.append(oid)
-
-    # LAG members validation
-    lag_mbr = sai.get_vid(SaiObjType.LAG_MEMBER)
-    mbr_len = len(lag_mbr)
-    assert mbr_len == 2
-    for x in range(mbr_len):
-        assert lag_members_id[x] == list(lag_mbr.keys())[x].split(',')[1]
+    lag_mbr_oids = []
+    for oid in sai.sw.port_oids[1:3]:
+        lag_mbr = sai.create(SaiObjType.LAG_MEMBER,
+                             [
+                                 "SAI_LAG_MEMBER_ATTR_LAG_ID", lag_oid,
+                                 "SAI_LAG_MEMBER_ATTR_PORT_ID", oid
+                             ])
+        lag_mbr_oids.append(lag_mbr)
 
     # Create RIF2
-    rif_oid2 = sai.get_vid(SaiObjType.ROUTER_INTERFACE, "rif2")
-    sai.create("SAI_OBJECT_TYPE_ROUTER_INTERFACE:" + rif_oid2,
-               [
-                   'SAI_ROUTER_INTERFACE_ATTR_TYPE', 'SAI_ROUTER_INTERFACE_TYPE_PORT',
-                   'SAI_ROUTER_INTERFACE_ATTR_PORT_ID', lag_oid,
-                   'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID', vrf_oid2,
-               ])
+    rif_oid2 = sai.create(SaiObjType.ROUTER_INTERFACE,
+                          [
+                              'SAI_ROUTER_INTERFACE_ATTR_TYPE', 'SAI_ROUTER_INTERFACE_TYPE_PORT',
+                              'SAI_ROUTER_INTERFACE_ATTR_PORT_ID', lag_oid,
+                              'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID', vrf_oid2,
+                          ])
 
-
-def test_rif_remove(sai):
-    # Delete RIF1
-    rif_oid1 = sai.get_vid(SaiObjType.ROUTER_INTERFACE, "rif1")
-    sai.remove("SAI_OBJECT_TYPE_ROUTER_INTERFACE:" + rif_oid1)
-
-    # Delete RIF2
-    rif_oid2 = sai.get_vid(SaiObjType.ROUTER_INTERFACE, "rif2")
-    sai.remove("SAI_OBJECT_TYPE_ROUTER_INTERFACE:" + rif_oid2)
+    # Delete RIFs
+    sai.remove(rif_oid1)
+    sai.remove(rif_oid2)
 
     # Delete LAG1 members
-    lag_oid = sai.get_vid(SaiObjType.LAG, "lag1")
-    lag_mbr_key = []
-    lag_mbr = sai.get_vid(SaiObjType.LAG_MEMBER)
-    for item in lag_mbr.items():
-        if lag_oid in item[0]:
-            lag_mbr_key.append(item[0])
-
-    port_oids = []
-    for key in lag_mbr_key:
-        oid = sai.pop_vid(SaiObjType.LAG_MEMBER, key)
-        sai.remove("SAI_OBJECT_TYPE_LAG_MEMBER:" + oid)
-        port_oids.append(key.split(',')[1])
+    for oid in lag_mbr_oids:
+        sai.remove(oid)
 
     # Delete LAG1
-    sai.remove("SAI_OBJECT_TYPE_LAG:" + lag_oid)
+    sai.remove(lag_oid)
 
-    # Delete VRF1
-    vrf_oid1 = sai.get_vid(SaiObjType.VIRTUAL_ROUTER, "vrf1")
-    sai.remove("SAI_OBJECT_TYPE_VIRTUAL_ROUTER:" + vrf_oid1)
-
-    # Delete VRF2
-    vrf_oid2 = sai.get_vid(SaiObjType.VIRTUAL_ROUTER, "vrf2")
-    sai.remove("SAI_OBJECT_TYPE_VIRTUAL_ROUTER:" + vrf_oid2)
+    # Delete VRFs
+    sai.remove(vrf_oid1)
+    sai.remove(vrf_oid2)
 
     # Create bridge port for ports removed from LAG
-    for idx, oid in enumerate(port_oids):
-        bp_oid = sai.get_vid(SaiObjType.BRIDGE_PORT, oid)
-        sai.create("SAI_OBJECT_TYPE_BRIDGE_PORT:" + bp_oid,
-                   [
-                       "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
-                       "SAI_BRIDGE_PORT_ATTR_PORT_ID", oid,
-                       # "SAI_BRIDGE_PORT_ATTR_BRIDGE_ID", dot1q_br.oid(),
-                       "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true"
-                   ])
+    for idx, oid in enumerate(sai.sw.port_oids[0:3]):
+        bp_oid = sai.create(SaiObjType.BRIDGE_PORT,
+                            [
+                                "SAI_BRIDGE_PORT_ATTR_TYPE", "SAI_BRIDGE_PORT_TYPE_PORT",
+                                "SAI_BRIDGE_PORT_ATTR_PORT_ID", oid,
+                                # "SAI_BRIDGE_PORT_ATTR_BRIDGE_ID", dot1q_br.oid(),
+                                "SAI_BRIDGE_PORT_ATTR_ADMIN_STATE", "true"
+                            ])
         sai.sw.dot1q_bp_oids[idx] = bp_oid
 
     # Add ports to default VLAN and set PVID
-    for idx in range(len(port_oids)):
-        sai.create_vlan_member(sai.sw.default_vlan_id, sai.sw.dot1q_bp_oids[idx], "SAI_VLAN_TAGGING_MODE_UNTAGGED")
-        sai.set("SAI_OBJECT_TYPE_PORT:" + port_oids[idx], ["SAI_PORT_ATTR_PORT_VLAN_ID", sai.sw.default_vlan_id])
+    for idx, oid in enumerate(sai.sw.port_oids[0:3]):
+        sai.create_vlan_member(sai.sw.default_vlan_oid, sai.sw.dot1q_bp_oids[idx], "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+        sai.set(oid, ["SAI_PORT_ATTR_PORT_VLAN_ID", sai.sw.default_vlan_id])


### PR DESCRIPTION
```
================================================================= test session starts =================================================================
platform linux -- Python 3.7.3, pytest-6.2.3, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sai-challenger, configfile: pytest.ini
collected 18 items                                                                                                                                    

test_l2_basic.py::test_l2_access_to_access_vlan PASSED                                                                                          [  5%]
test_l2_basic.py::test_l2_trunk_to_trunk_vlan PASSED                                                                                            [ 11%]
test_l2_basic.py::test_l2_access_to_trunk_vlan PASSED                                                                                           [ 16%]
test_l2_basic.py::test_l2_trunk_to_access_vlan PASSED                                                                                           [ 22%]
test_l2_basic.py::test_l2_flood PASSED                                                                                                          [ 27%]
test_l2_basic.py::test_l2_lag PASSED                                                                                                            [ 33%]
test_l2_basic.py::test_l2_vlan_bcast_ucast PASSED                                                                                               [ 38%]
test_l2_basic.py::test_l2_mtu PASSED                                                                                                            [ 44%]
test_sairec.py::test_apply_sairec[BCM56850/empty_sw.rec] PASSED                                                                                 [ 50%]
test_sairec.py::test_apply_sairec[BCM56850/bridge_create_1.rec] PASSED                                                                          [ 55%]
test_sairec.py::test_apply_sairec[BCM56850/hostif.rec] PASSED                                                                                   [ 61%]
test_sairec.py::test_apply_sairec[BCM56850/acl_tables.rec] PASSED                                                                               [ 66%]
test_sairec.py::test_apply_sairec[BCM56850/bulk_fdb.rec] PASSED                                                                                 [ 72%]
test_sairec.py::test_apply_sairec[BCM56850/bulk_route.rec] PASSED                                                                               [ 77%]
test_sairec.py::test_apply_sairec[BCM56850/remove_create_port.rec] PASSED                                                                       [ 83%]
test_stats.py::test_stats PASSED                                                                                                                [ 88%]
test_vrf.py::test_default_vrf PASSED                                                                                                            [ 94%]
test_vrf.py::test_rif_create_remove PASSED                                                                                                      [100%]

================================================================= 18 passed in 26.76s =================================================================
```