### PR TITLE
RIF UT for types: Port and Vlan

### DIFF
--- a/tests/test_l2_basic.py
+++ b/tests/test_l2_basic.py
@@ -506,3 +506,108 @@ def test_fdb_bulk_remove(npu, dataplane):
 
     finally:
         npu.flush_fdb_entries(["SAI_FDB_FLUSH_ATTR_BV_ID", npu.default_vlan_oid])
+def test_l2_mac_move_1(npu, dataplane):
+    '''
+    Description:
+    Create VLAN, e.g. 100 and add member ports 1, 2 and 3. Send packet on port 1 with
+    src_mac=MAC1 and dst_mac= MAC2. Verify MAC1 is learnt on port 1 and packet is flooded
+    to other member ports (2 and 3 in this example). Send packet on port 2 with src_mac=MAC2
+    and dst_mac= MAC1. Verify MAC2 is learnt on port 2. After learning, verify that packet
+    from port 1 is only forwarded to port 2 and not to port 3. Repeat the test by sending
+    same packet (src_mac=MAC2 and dst_mac= MAC1), on port 3. Verify that stationmovement
+    occurred and MAC2 is learnt on port 3. Packet from port 1 destined to MAC2 must be forwarded
+    to port 3 and not to port 2 after the MAC-movement.
+    Steps:
+    1. Create VLAN 100 and associate 3 untagged ports (port 1,2,3) as the member port of VLAN 100.
+    2. Set attribute value of "Port VLAN ID 100" for the ports 1, 2, 3
+    3. Send packet from port 1 with src_mac=MAC1 and dst_mac= MAC2
+    4. Send packet from port 2 with src_mac=MAC2 and dst_mac= MAC1.
+    5. After MAC learning, repeat step 3 and verify that packet from port 1 is only forwarded to port 2 and not to port 3.
+    6. Send packet (src_mac=MAC2 and dst_mac= MAC1) on port 3
+    7. Send packet (src_mac=MAC1 and dst_mac=MAC2) from port 1.
+    8. Clean up by remove the vlan members and the VLAN from the database.
+    '''
+    print('L2 Mac Move test on Access ports 1,2 and 3')
+
+    vlan_id = "100"
+    macs = ['00:11:11:11:11:11', '00:22:22:22:22:22']
+    max_port = 3
+    vlan_mbr_oids = []
+    ### create vlan
+    vlan_oid = npu.create(SaiObjType.VLAN, ["SAI_VLAN_ATTR_VLAN_ID", vlan_id])
+
+    ### create vlan membership with ports
+    for idx in range(max_port):
+        npu.remove_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[idx])
+        vlan_mbr = npu.create_vlan_member(vlan_oid, npu.dot1q_bp_oids[idx], "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+        vlan_mbr_oids.append(vlan_mbr)
+        npu.set(npu.port_oids[idx], ["SAI_PORT_ATTR_PORT_VLAN_ID", vlan_id])
+    
+    try:
+        if npu.run_traffic:
+            pkt1 = simple_tcp_packet(eth_dst=macs[1],
+                                     eth_src=macs[0],
+                                     ip_dst='192.168.0.2',
+                                     ip_src='192.168.0.1',
+                                     ip_id=105,
+                                     ip_ttl=64)
+
+            pkt2 = simple_tcp_packet(eth_dst=macs[0],
+                                     eth_src=macs[1],
+                                     ip_dst='192.168.0.1',
+                                     ip_src='192.168.0.2',
+                                     ip_id=105,
+                                     ip_ttl=64)
+                  
+            send_packet(dataplane, 0, pkt)
+            verify_packets(dataplane, pkt, [1])
+
+            ### Sending packet from Port1
+            send_packet(dataplane, 0, pkt1)
+
+            ### verify the packet @ Port2 and Port3
+            verify_packets(dataplane, pkt1, [1, 2])
+
+            ### Sending packet from Port2
+            send_packet(dataplane, 1, pkt2)
+
+            ### verify the packet @ Port1
+            verify_packets(dataplane, pkt2, [0])
+
+            time.sleep(1)
+
+            ### Sending packet from Port1
+            send_packet(dataplane, 0, pkt1)
+
+            ### verify the packet @ Port2
+            verify_packets(dataplane, pkt1, [1])
+
+            ### verify no packet @ Port3
+            verify_no_packet(dataplane, pkt1, 2)
+
+            time.sleep(1)
+
+            ### Send packet (src_mac=MAC2 and dst_mac= MAC1) on port3
+            send_packet(dataplane, 2, pkt2)
+
+            ### verify the packet @ Port1
+            verify_packets(dataplane, pkt2, [0])
+
+            time.sleep(1)
+
+            ### Send packet (src_mac=MAC1 and dst_mac=MAC2) from port 1
+            send_packet(dataplane, 0, pkt1)
+
+            ### verify the packet @ Port3 & no packet @ Port2
+            verify_packets(dataplane, pkt1, [2])
+            verify_no_packet(dataplane, pkt1, 1)
+   
+    finally:
+        ### Assign ports into default vlan and remove vlan membership from ports
+        for idx in range(max_port):
+            npu.remove(vlan_mbr_oids[idx])
+            npu.create_vlan_member(npu.default_vlan_oid, npu.dot1q_bp_oids[idx], "SAI_VLAN_TAGGING_MODE_UNTAGGED")
+            npu.set(npu.port_oids[idx], ["SAI_PORT_ATTR_PORT_VLAN_ID", npu.default_vlan_id])
+        
+        ### remove valn
+        npu.remove(vlan_oid)

--- a/tests/ut/test_rif.py
+++ b/tests/ut/test_rif.py
@@ -1,0 +1,178 @@
+import pytest
+from sai import SaiObjType
+
+rif_attrs = [
+    ("SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID",             "sai_object_id_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_TYPE",                          "sai_router_interface_type_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_PORT_ID",                       "sai_object_id_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_VLAN_ID",                       "sai_object_id_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS",               "sai_mac_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE",                "bool"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE",                "bool"),
+    ("SAI_ROUTER_INTERFACE_ATTR_MTU",                           "sai_uint32_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_INGRESS_ACL",                   "sai_object_id_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_EGRESS_ACL",                    "sai_object_id_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NEIGHBOR_MISS_PACKET_ACTION",   "sai_packet_action_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_V4_MCAST_ENABLE",               "bool"),
+    ("SAI_ROUTER_INTERFACE_ATTR_V6_MCAST_ENABLE",               "bool"),
+    ("SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION",        "sai_packet_action_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_IS_VIRTUAL",                    "bool"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NAT_ZONE_ID",                   "sai_uint8_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_DISABLE_DECREMENT_TTL",         "bool"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE",              "bool")
+]
+
+rif_attrs_default = {}
+rif_attrs_updated = {}
+
+
+@pytest.fixture(scope="module")
+def sai_rif_obj_port(npu):
+    vrf_oid1 = npu.create(SaiObjType.VIRTUAL_ROUTER, [])
+    rif_oid = npu.create(SaiObjType.ROUTER_INTERFACE,
+                         [
+                             'SAI_ROUTER_INTERFACE_ATTR_TYPE', 'SAI_ROUTER_INTERFACE_TYPE_PORT',
+                             'SAI_ROUTER_INTERFACE_ATTR_PORT_ID', npu.port_oids[0],
+                             'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID', vrf_oid1
+                         ])
+    yield rif_oid
+    npu.remove(rif_oid)
+
+
+@pytest.fixture(scope="module")
+def sai_rif_obj_vlan(npu):
+    vlan_oid = npu.create(SaiObjType.VLAN, ["SAI_VLAN_ATTR_VLAN_ID", "10"])
+    vrf_oid1 = npu.create(SaiObjType.VIRTUAL_ROUTER, [])
+    rif_oid = npu.create(SaiObjType.ROUTER_INTERFACE,
+                         [
+                             'SAI_ROUTER_INTERFACE_ATTR_TYPE', 'SAI_ROUTER_INTERFACE_TYPE_VLAN',
+                             'SAI_ROUTER_INTERFACE_ATTR_VLAN_ID', vlan_oid,
+                             'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID', vrf_oid1
+                         ])
+    yield rif_oid
+    npu.remove(rif_oid)
+    npu.remove(vrf_oid1)
+    npu.remove(vlan_oid)
+
+
+@pytest.mark.parametrize(
+    "attr,attr_type",
+    rif_attrs
+)
+def test_get_before_set_attr_port(npu, dataplane, sai_rif_obj_port, attr, attr_type):
+    status, data = npu.get_by_type(sai_rif_obj_port, attr, attr_type, do_assert=False)
+    npu.assert_status_success(status)
+    if status == "SAI_STATUS_SUCCESS":
+        rif_attrs_default[attr] = data.value()
+
+
+@pytest.mark.parametrize(
+    "attr,attr_type",
+    rif_attrs
+)
+def test_get_before_set_attr_vlan(npu, dataplane, sai_rif_obj_vlan, attr, attr_type):
+    status, data = npu.get_by_type(sai_rif_obj_vlan, attr, attr_type, do_assert=False)
+    npu.assert_status_success(status)
+    if status == "SAI_STATUS_SUCCESS":
+        rif_attrs_default[attr] = data.value()
+
+
+valued_attr = [
+    ("SAI_ROUTER_INTERFACE_ATTR_TYPE",                              "SAI_ROUTER_INTERFACE_TYPE_PORT"),
+    ("SAI_ROUTER_INTERFACE_ATTR_TYPE",                              "SAI_ROUTER_INTERFACE_TYPE_VLAN"),
+    ("SAI_ROUTER_INTERFACE_ATTR_PORT_ID",                           "oid:0x0"),
+    ("SAI_ROUTER_INTERFACE_ATTR_VLAN_ID",                           "oid:0x0"),
+    ("SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS",                   "00:11:11:11:11:11"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE",                    "true"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE",                    "false"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE",                    "true"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE",                    "false"),
+    ("SAI_ROUTER_INTERFACE_ATTR_MTU",                               "1500"),
+    ("SAI_ROUTER_INTERFACE_ATTR_INGRESS_ACL",                       "oid:0x0"),
+    ("SAI_ROUTER_INTERFACE_ATTR_EGRESS_ACL",                        "oid:0x0"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NEIGHBOR_MISS_PACKET_ACTION",       "SAI_PACKET_ACTION_DROP"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NEIGHBOR_MISS_PACKET_ACTION",       "SAI_PACKET_ACTION_FORWARD"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NEIGHBOR_MISS_PACKET_ACTION",       "SAI_PACKET_ACTION_COPY"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NEIGHBOR_MISS_PACKET_ACTION",       "SAI_PACKET_ACTION_COPY_CANCEL"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NEIGHBOR_MISS_PACKET_ACTION",       "SAI_PACKET_ACTION_TRAP"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NEIGHBOR_MISS_PACKET_ACTION",       "SAI_PACKET_ACTION_LOG"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NEIGHBOR_MISS_PACKET_ACTION",       "SAI_PACKET_ACTION_DENY"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NEIGHBOR_MISS_PACKET_ACTION",       "SAI_PACKET_ACTION_TRANSIT"),
+    ("SAI_ROUTER_INTERFACE_ATTR_V4_MCAST_ENABLE",                   "true"),
+    ("SAI_ROUTER_INTERFACE_ATTR_V4_MCAST_ENABLE",                   "false"),
+    ("SAI_ROUTER_INTERFACE_ATTR_V6_MCAST_ENABLE",                   "true"),
+    ("SAI_ROUTER_INTERFACE_ATTR_V6_MCAST_ENABLE",                   "false"),
+    ("SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION",            "SAI_PACKET_ACTION_DROP"),
+    ("SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION",            "SAI_PACKET_ACTION_FORWARD"),
+    ("SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION",            "SAI_PACKET_ACTION_COPY"),
+    ("SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION",            "SAI_PACKET_ACTION_COPY_CANCEL"),
+    ("SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION",            "SAI_PACKET_ACTION_TRAP"),
+    ("SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION",            "SAI_PACKET_ACTION_LOG"),
+    ("SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION",            "SAI_PACKET_ACTION_DENY"),
+    ("SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION",            "SAI_PACKET_ACTION_TRANSIT"),
+    ("SAI_ROUTER_INTERFACE_ATTR_IS_VIRTUAL",                        "true"),
+    ("SAI_ROUTER_INTERFACE_ATTR_IS_VIRTUAL",                        "false"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NAT_ZONE_ID",                       "2"),
+    ("SAI_ROUTER_INTERFACE_ATTR_DISABLE_DECREMENT_TTL",             "true"),
+    ("SAI_ROUTER_INTERFACE_ATTR_DISABLE_DECREMENT_TTL",             "false"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE",                  "true"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE",                  "false")
+]
+
+
+@pytest.mark.parametrize(
+    "attr,attr_value",
+    valued_attr
+)
+def test_set_attr_port(npu, dataplane, sai_rif_obj_port, attr, attr_value):
+    status = npu.set(sai_rif_obj_port, [attr, attr_value], False)
+    npu.assert_status_success(status)
+    if status == "SAI_STATUS_SUCCESS":
+        rif_attrs_updated[attr] = attr_value
+
+
+@pytest.mark.parametrize(
+    "attr,attr_value",
+    valued_attr
+)
+def test_set_attr_vlan(npu, dataplane, sai_rif_obj_vlan, attr, attr_value):
+    status = npu.set(sai_rif_obj_vlan, [attr, attr_value], False)
+    npu.assert_status_success(status)
+    if status == "SAI_STATUS_SUCCESS":
+        rif_attrs_updated[attr] = attr_value
+
+
+rif_attrs = [
+    ("SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS",               "sai_mac_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE",                "bool"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE",                "bool"),
+    ("SAI_ROUTER_INTERFACE_ATTR_MTU",                           "sai_uint32_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_INGRESS_ACL",                   "sai_object_id_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_EGRESS_ACL",                    "sai_object_id_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_NEIGHBOR_MISS_PACKET_ACTION",   "sai_packet_action_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_V4_MCAST_ENABLE",               "bool"),
+    ("SAI_ROUTER_INTERFACE_ATTR_V6_MCAST_ENABLE",               "bool"),
+    ("SAI_ROUTER_INTERFACE_ATTR_LOOPBACK_PACKET_ACTION",        "sai_packet_action_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_IS_VIRTUAL",                    "bool"),  # !
+    ("SAI_ROUTER_INTERFACE_ATTR_NAT_ZONE_ID",                   "sai_uint8_t"),
+    ("SAI_ROUTER_INTERFACE_ATTR_DISABLE_DECREMENT_TTL",         "bool"),
+    ("SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE",              "bool"),
+]
+
+
+@pytest.mark.parametrize(
+    "attr,attr_type",
+    rif_attrs
+)
+def test_get_after_set_attr_port(npu, dataplane, sai_rif_obj_port, attr, attr_type):
+    status, data = npu.get_by_type(sai_rif_obj_vlan, attr, attr_type, do_assert=False)
+    npu.assert_status_success(status)
+
+
+@pytest.mark.parametrize(
+    "attr,attr_type",
+    rif_attrs
+)
+def test_get_after_set_attr_vlan(npu, dataplane, sai_rif_obj_vlan, attr, attr_type):
+    status, data = npu.get_by_type(sai_rif_obj_vlan, attr, attr_type, do_assert=False)
+    npu.assert_status_success(status)


### PR DESCRIPTION
Can not properly create RIF object with type vlan

test_get_before_set_attr_port passed only for:
SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID"
"SAI_ROUTER_INTERFACE_ATTR_TYPE"
"SAI_ROUTER_INTERFACE_ATTR_PORT_ID"

And skipped for 
"SAI_ROUTER_INTERFACE_ATTR_VLAN_ID" as not implemented